### PR TITLE
Tree

### DIFF
--- a/scheme/stack.scm
+++ b/scheme/stack.scm
@@ -75,4 +75,3 @@
 (export pop)
 (export store)
 (export name)
-

--- a/scheme/tree.scm
+++ b/scheme/tree.scm
@@ -103,6 +103,13 @@
         (tree-set! tree path (proc #f val)))
     ))
 
+; merge values of tree2 into tree1
+(define-method (tree-merge! (tree1 <tree>) (proc <procedure>) (tree2 <tree>))
+  (tree-walk tree2 '()
+    (lambda (path nkey value)
+      (tree-merge! tree1 path proc value)
+      )))
+
 ; get value at path
 ; returns #f if path is not present or if its value is #f
 ; to discern use tree-get-node
@@ -248,9 +255,9 @@
 
 ; walk the tree and call callback for every node
 (define-method (tree-walk (tree <tree>) (path <list>) (callback <procedure>) . opts)
-  (let ((dosort (assoc-get 'sort opts))
+  (let ((dosort (assoc-get 'sort opts #f))
         (sortby (assoc-get 'sortby opts stdsort))
-        (doempty (assoc-get 'empty opts)))
+        (doempty (assoc-get 'empty opts #f)))
     (if (or doempty (has-value tree))
         (callback path (key tree) (value tree)))
     (for-each (lambda (p)

--- a/scheme/tree.scm
+++ b/scheme/tree.scm
@@ -137,6 +137,8 @@
 ; if skey=global and path=music.momnt.brass.trumpet
 ; it looks for global, music.global, music.momnt.global, music.momnt.brass.global
 ; and music.momnt.brass.trumpet.global and returns the last value found
+(define-method (tree-get-from-path (tree <tree>) (path <list>) skey)
+  (tree-get-from-path tree path skey #f))
 (define-method (tree-get-from-path (tree <tree>) (path <list>) skey val)
   (if (equal? skey (key tree))(set! val (value tree)))
   (let ((child (hash-ref (children tree) skey)))
@@ -317,6 +319,7 @@
 (export tree-get)
 (export tree-get-node)
 (export tree-get-from-path)
+(export tree-get-node-from-path)
 (export tree-get-keys)
 (export tree-dispatch)
 (export tree-collect)

--- a/scheme/tree.scm
+++ b/scheme/tree.scm
@@ -155,10 +155,11 @@
 ; if skey=global and path=music.momnt.brass.trumpet
 ; it looks for global, music.global, music.momnt.global, music.momnt.brass.global
 ; and music.momnt.brass.trumpet.global and returns the last value found
+; TODO predicate?
 (define-method (tree-get-node-from-path (tree <tree>) (path <list>) skey val)
   (if (equal? skey (key tree))(set! val (value tree)))
   (let ((child (hash-ref (children tree) skey)))
-    (if (is-a? child <tree>)(set! val (value child))))
+    (if (and (is-a? child <tree>)(has-value child))(set! val (value child))))
   (if (= (length path) 0)
       val
       (let* ((ckey (car path))
@@ -166,7 +167,7 @@
              (child (hash-ref (children tree) ckey))
              )
         (if (is-a? child <tree>)
-            (tree-get-from-path child cpath skey val)
+            (tree-get-node-from-path child cpath skey val)
             val)
         )))
 

--- a/scheme/tree.scm
+++ b/scheme/tree.scm
@@ -156,10 +156,14 @@
 ; it looks for global, music.global, music.momnt.global, music.momnt.brass.global
 ; and music.momnt.brass.trumpet.global and returns the last value found
 ; TODO predicate?
+(define-method (tree-get-node-from-path (tree <tree>) (path <list>) skey)
+  (tree-get-node-from-path tree path skey #f))
 (define-method (tree-get-node-from-path (tree <tree>) (path <list>) skey val)
-  (if (equal? skey (key tree))(set! val (value tree)))
+  (if (and (equal? skey (key tree))(has-value tree))
+      (set! val (cons skey (value tree))))
   (let ((child (hash-ref (children tree) skey)))
-    (if (and (is-a? child <tree>)(has-value child))(set! val (value child))))
+    (if (and (is-a? child <tree>)(has-value child))
+        (set! val (cons skey (value child)))))
   (if (= (length path) 0)
       val
       (let* ((ckey (car path))

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -60,4 +60,15 @@ mytree = #(tree-create 'my-tree)
 #(display (tree-collect mytree '(a b c d e f)))
 #(newline)
 
+#(display "-----------------------------------------")
+#(newline)
+#(tree-merge! mytree '(a b) + 33)
+#(display mytree)
+
+
+% TBD explain tree-merge!
+#(tree-set! mytree '(mods) #{ \with { \override NoteHead.color = #red } #})
+#(tree-merge! mytree '(mods) (lambda (m1 m2) #{ \with { $m1 $m2 } #}) #{ \with { \override Beam.color = #red } #})
+
+#(display mytree)
 

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -1,0 +1,63 @@
+\version "2.19.38"
+\include "oll-core.ily"
+
+#(use-modules (oll-core scheme tree))
+
+% create tree object
+mytree = #(tree-create 'my-tree)
+
+#(tree-set! mytree '(x y z) #f) % set value #f at x/y/z
+#(tree-set! mytree '(a b c) #t) % set value #t at a/b/c
+#(tree-set! mytree '(a b) 42) % set value 42 at a/b
+#(tree-set! mytree '(global) 24) % set value 24 at global
+#(display mytree) % display tree
+
+#(display "-----------------------------------------")
+#(newline)
+#(display "(tree-get mytree '(a)) : ")
+#(display (tree-get mytree '(a)))
+#(newline)
+#(display "(tree-get mytree '(a b)) : ")
+#(display (tree-get mytree '(a b)))
+#(newline)
+#(display "(tree-get mytree '(a b c)) : ")
+#(display (tree-get mytree '(a b c)))
+#(newline)
+#(display "(tree-get mytree '(x y)) : ")
+#(display (tree-get mytree '(x y)))
+#(newline)
+#(display "(tree-get-node mytree '(x y)) : ")
+#(display (tree-get-node mytree '(x y)))
+#(newline)
+#(display "(tree-get mytree '(x y z)) : ")
+#(display (tree-get mytree '(x y z)))
+#(newline)
+#(display "(tree-get-node mytree '(x y z)) : ")
+#(display (tree-get-node mytree '(x y z)))
+#(newline)
+#(display "-----------------------------------------")
+#(newline)
+% 
+#(display "(tree-get-from-path mytree '(a b c d e f) 'b) : ")
+#(display (tree-get-from-path mytree '(a b c d e f) 'b))
+#(newline)
+#(display "(tree-get-node-from-path mytree '(a b c d e f) 'b) : ")
+#(display (tree-get-node-from-path mytree '(a b c d e f) 'b))
+#(newline)
+#(display "(tree-get-node-from-path mytree '(a b c d e f) 'not-found) : ")
+#(display (tree-get-node-from-path mytree '(a b c d e f) 'not-found))
+#(newline)
+#(display "(tree-get-node-from-path mytree '(a b c d e f) 'x #f) : ")
+#(display (tree-get-node-from-path mytree '(a b c d e f) 'x #f))
+#(newline)
+
+% return pair with extra-path and value fond within path
+#(display "(tree-dispatch mytree '(a b c d e f)) : ")
+#(display (tree-dispatch mytree '(a b c d e f)))
+#(newline)
+% collect all values found on path
+#(display "(tree-collect mytree '(a b c d e f)) : ")
+#(display (tree-collect mytree '(a b c d e f)))
+#(newline)
+
+

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -37,7 +37,7 @@ mytree = #(tree-create 'my-tree)
 #(newline)
 #(display "-----------------------------------------")
 #(newline)
-% 
+%
 #(display "(tree-get-from-path mytree '(a b c d e f) 'b) : ")
 #(display (tree-get-from-path mytree '(a b c d e f) 'b))
 #(newline)
@@ -62,13 +62,20 @@ mytree = #(tree-create 'my-tree)
 
 #(display "-----------------------------------------")
 #(newline)
+% TBD explain tree-merge!
 #(tree-merge! mytree '(a b) + 33)
 #(display mytree)
 
+#(display "-----------------------------------------")
+#(newline)
 
-% TBD explain tree-merge!
 #(tree-set! mytree '(mods) #{ \with { \override NoteHead.color = #red } #})
 #(tree-merge! mytree '(mods) (lambda (m1 m2) #{ \with { $m1 $m2 } #}) #{ \with { \override Beam.color = #red } #})
+
+mytreeB = #(tree-create 'my-other-tree)
+#(tree-set! mytreeB '(a b) 42) % set value 42 at a/b
+#(tree-set! mytreeB '(global) 24) % set value 24 at global
+#(tree-merge! mytree + mytreeB)
 
 #(display mytree)
 

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -4,6 +4,8 @@
 #(use-modules (oll-core scheme tree))
 
 % create tree object
+#(display "(tree-create 'my-tree) : ")
+#(newline)
 mytree = #(tree-create 'my-tree)
 
 #(tree-set! mytree '(x y z) #f) % set value #f at x/y/z
@@ -63,18 +65,20 @@ mytree = #(tree-create 'my-tree)
 #(display "-----------------------------------------")
 #(newline)
 % TBD explain tree-merge!
+#(display "(tree-merge! mytree '(a b) + 33) : ")
+#(newline)
 #(tree-merge! mytree '(a b) + 33)
 #(display mytree)
-
-#(display "-----------------------------------------")
-#(newline)
-
 #(tree-set! mytree '(mods) #{ \with { \override NoteHead.color = #red } #})
 #(tree-merge! mytree '(mods) (lambda (m1 m2) #{ \with { $m1 $m2 } #}) #{ \with { \override Beam.color = #red } #})
-
+#(display "(tree-create 'my-other-tree)")
+#(newline)
 mytreeB = #(tree-create 'my-other-tree)
 #(tree-set! mytreeB '(a b) 42) % set value 42 at a/b
 #(tree-set! mytreeB '(global) 24) % set value 24 at global
+#(display mytreeB)
+#(display "(tree-merge! mytree + mytreeB) : ")
+#(newline)
 #(tree-merge! mytree + mytreeB)
 
 #(display mytree)


### PR DESCRIPTION
I merged the former state of the get-node method. But after thinking twice, I saw, that you will get a pair '(key . #f) if there are values stored deeper in the tree. So I introduced a member "has-value" to the tree class, which is used to discern a #f-value from no value.

I reviewed the functions and added some examples to tree.ly in usage-examples.
 
