### PR TITLE
Add tree-register-type! method

### DIFF
--- a/scheme/tree.scm
+++ b/scheme/tree.scm
@@ -49,7 +49,7 @@
   (key #:accessor key #:init-keyword #:key #:init-value 'node)
   (value #:accessor value #:setter set-value! #:init-value #f)
   (has-value #:accessor has-value #:setter has-value! #:init-value #f)
-  (has-type #:accessor has-type #:setter has-type! #:init-value #f)
+  (type #:accessor type #:setter set-type! #:init-value #f)
   )
 
 ; set value at path
@@ -64,17 +64,17 @@
 (define-method (tree-set! (create <boolean>) (tree <tree>) (path <list>) val)
   (if (= (length path) 0)
       ;; end of path reached: set value
-      (let ((pred (has-type tree)))
-        (if pred
+      (let ((pred? (type tree)))
+        (if pred?
             ;; if tree has a type defined check value against it before setting
-            (if (pred val)
+            (if (pred? val)
                 (begin
                  (set-value! tree val)
                  (has-value! tree #t))
                 (begin
                  (ly:input-warning (*location*)
                    (format "TODO: Format warning about typecheck error in tree-set!
-Expected ~a, got ~a" pred val))
+Expected ~a, got ~a" (procedure-name pred?) val))
                  (set! val #f)))
             ;; if no typecheck is set simply set the value
             (begin
@@ -121,11 +121,11 @@ Path: ~a" path)))))
           ))
     val))
 
-(define-method (tree-register-type! (tree <tree>) (path <list>)(predicate <procedure>))
+(define-method (tree-set-type! (tree <tree>) (path <list>)(predicate <procedure>))
   (if (= (length path) 0)
       ;; end of path reached: register type
       (begin
-       (has-type! tree predicate)
+       (set-type! tree predicate)
        ; TODO: What to do if there already is a value?
        ; probably: check type and issue an oll-warning
        )
@@ -138,7 +138,7 @@ Path: ~a" path)))))
             (begin (set! child (make <tree> #:key ckey))
               (hash-set! (children tree) ckey child)))
         ;; recursively walk path
-        (tree-register-type! child cpath predicate))
+        (tree-set-type! child cpath predicate))
       ))
 
 ; merge value at path into tree
@@ -369,7 +369,7 @@ Path: ~a" path)))))
 ; export methods
 (export tree-set!)
 (export tree-unset!)
-(export tree-register-type!)
+(export tree-set-type!)
 (export tree-merge!)
 (export tree-get-tree)
 (export tree-get)

--- a/scheme/tree.scm
+++ b/scheme/tree.scm
@@ -53,8 +53,15 @@
   )
 
 ; set value at path
+; if the node at path has a type first check against that
 ; if the path doesn't exist yet intermediate nodes are created implicitly
 (define-method (tree-set! (tree <tree>) (path <list>) val)
+  (tree-set! #t tree path val))
+
+; set value at path
+; if create is #t missing intermediate nodes are created implicitly
+; if the node at path has a type first check against that
+(define-method (tree-set! (create <boolean>) (tree <tree>) (path <list>) val)
   (if (= (length path) 0)
       ;; end of path reached: set value
       (let ((pred (has-type tree)))
@@ -79,11 +86,17 @@ Expected ~a, got ~a" pred val))
              (cpath (cdr path))
              (child (hash-ref (children tree) ckey)))
         (if (not (tree? child))
-            ;; create child node if not present
-            (begin (set! child (make <tree> #:key ckey))
-              (hash-set! (children tree) ckey child)))
-        ;; recursively walk path
-        (tree-set! child cpath val)))
+            ;; create child node if option is set
+            (if create
+                (begin 
+                 (set! child (make <tree> #:key ckey))
+                 (hash-set! (children tree) ckey child))))
+        (if (tree? child)
+            ;; recursively walk path
+            (tree-set! create child cpath val)
+            (ly:input-warning (*location*)
+              (format "TODO: Format missing path warning in tree-set!
+Path: ~a" path)))))
   val)
 
 ; unset value at path

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -69,6 +69,12 @@ mytree = #(tree-create 'my-tree)
 #(newline)
 #(tree-merge! mytree '(a b) + 33)
 #(display mytree)
+
+#(tree-register-type! mytree '(a b d) string?)
+#(tree-set! mytree '(a b d) 234)
+#(tree-set! mytree '(a b d) "234")
+
+% TBD explain tree-merge!
 #(tree-set! mytree '(mods) #{ \with { \override NoteHead.color = #red } #})
 #(tree-merge! mytree '(mods) (lambda (m1 m2) #{ \with { $m1 $m2 } #}) #{ \with { \override Beam.color = #red } #})
 #(display "(tree-create 'my-other-tree)")
@@ -82,4 +88,3 @@ mytreeB = #(tree-create 'my-other-tree)
 #(tree-merge! mytree + mytreeB)
 
 #(display mytree)
-

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -70,9 +70,15 @@ mytree = #(tree-create 'my-tree)
 #(tree-merge! mytree '(a b) + 33)
 #(display mytree)
 
+% a/b/d can only accept string? now
 #(tree-register-type! mytree '(a b d) string?)
+% issues a warning and doesn't set the value
 #(tree-set! mytree '(a b d) 234)
-#(tree-set! mytree '(a b d) "234")
+#(tree-set! #t mytree '(a b d) "234")
+% This doesn't set the value as a/b/e/f doesn't exist
+#(tree-set! #f mytree '(a b e f) 123)
+% This works because a is present
+#(tree-set! #f mytree '(a) "Oops")
 
 % TBD explain tree-merge!
 #(tree-set! mytree '(mods) #{ \with { \override NoteHead.color = #red } #})

--- a/usage-examples/tree.ly
+++ b/usage-examples/tree.ly
@@ -71,7 +71,7 @@ mytree = #(tree-create 'my-tree)
 #(display mytree)
 
 % a/b/d can only accept string? now
-#(tree-register-type! mytree '(a b d) string?)
+#(tree-set-type! mytree '(a b d) string?)
 % issues a warning and doesn't set the value
 #(tree-set! mytree '(a b d) 234)
 #(tree-set! #t mytree '(a b d) "234")


### PR DESCRIPTION
This is intended to make tree nodes type-aware.
Once a type (predicate) is registered with a node subsequently
a value can only be set when it passes the predicate check.

There are several questions, though:

* Is the name `tree-register-type!`appropriate?
* Is the implementation correct?
* What happens when a type is registered upon an existing and mismatching value?
* Is the changed behaviour of `tree-set!` appropriate? Or should it still set the value regardless of the warning?