### PR TITLE
Fix application of default values in optional props

### DIFF
--- a/internal/options.ily
+++ b/internal/options.ily
@@ -130,8 +130,8 @@
              (else #f))))))
 
 #(define (enforcement-symbol? obj)
-  (or (eq? 'strict obj)
-      (eq? 'flexible obj)))
+   (or (eq? 'strict obj)
+       (eq? 'flexible obj)))
 
 #(define (prop-rules? obj)
    "Check if given object is a property rules structure.
@@ -178,14 +178,15 @@
                  (default (third r))
                  (optional (fourth r))
                  (prop (assoc-get k props)))
-                (if (or prop optional)
-                    '()
-                    (if (null? default)
-                        (begin
-                         (ly:input-warning (*location*)
-                           "Missing mandatory property \"~a\"." k)
-                         '())
-                        (cons k default)))))
+                (cond
+                 (prop '())
+                 ((not (null? default)) (cons k default))
+                 (optional '())
+                 (else
+                  (begin
+                   (ly:input-warning (*location*)
+                     "Missing mandatory property \"~a\"." k)
+                   '())))))
           rules)))
      (props
       (delete '()


### PR DESCRIPTION
The case of optional properties with default values hadn't been reached.
Now we have the (cond) expression:
- property present: OK
- default present (while missing): use
- optional (while missing and no default): OK
- else (missing, not optional and no default): Warning and discard

@stroncaro I can't add you as a reviewer but I'd like to have your opinion before merging.