### PR TITLE
New Scheme modules (oll-core internal grob-tools) and ... music-tools

### DIFF
--- a/internal/init.ily
+++ b/internal/init.ily
@@ -45,6 +45,7 @@
 
 % A collection of general-purpose predicates
 #(use-modules (oll-core internal tools))
+#(use-modules (oll-core internal grob-tools))
 #(use-modules (oll-core internal control))
 
 % Version predicates to execute code for specific LilyPond versions

--- a/scheme/oll-core/internal/grob-tools.scm
+++ b/scheme/oll-core/internal/grob-tools.scm
@@ -1,0 +1,58 @@
+;%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+;%                                                                             %
+;% This file is part of openLilyLib,                                           %
+;%                      ===========                                            %
+;% the community library project for GNU LilyPond                              %
+;% (https://github.com/openlilylib/openlilylib                                 %
+;%              -----------                                                    %
+;%                                                                             %
+;% openLilyLib is free software: you can redistribute it and/or modify         %
+;% it under the terms of the GNU General Public License as published by        %
+;% the Free Software Foundation, either version 3 of the License, or           %
+;% (at your option) any later version.                                         %
+;%                                                                             %
+;% openLilyLib is distributed in the hope that it will be useful,              %
+;% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+;% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+;% GNU General Public License for more details.                                %
+;%                                                                             %
+;% You should have received a copy of the GNU General Public License           %
+;% along with openLilyLib. If not, see <http://www.gnu.org/licenses/>.         %
+;%                                                                             %
+;% openLilyLib is maintained by Urs Liska, ul@openlilylib.org                  %
+;% and others.                                                                 %
+;%       Copyright Urs Liska, 2018                                             %
+;%                                                                             %
+;%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+;; This files contains (convenience) tools for handling grobs
+;; (in callbacks or engravers)
+
+(define-module (oll-core internal grob-tools))
+(use-modules (lily))
+
+(define-public (grob-name grob)
+  "Returns the name/type of a grob."
+  (assq-ref (ly:grob-property grob 'meta) 'name))
+
+(define-public (filter-grobs-by-name name grob-list)
+  "Filters a list of grobs by a grob name/type"
+  (filter
+   (lambda (grob)
+     (eq? (grob-name grob) name))
+   grob-list))
+
+(define-public (stem-direction grob)
+  "Returns the stem-direction in the current note-column,
+    assuming there's a single Stem present in any column
+    (even for whole notes or rests)."
+  (let*
+   ((nc (ly:grob-parent grob X)))
+   (if (not (eq? (grob-name nc) 'NoteColumn))
+       #f
+       (let
+        ((stem
+          (car
+           (filter-grobs-by-name 'Stem
+             (ly:grob-array->list (ly:grob-object nc 'elements))))))
+        (ly:grob-property stem 'direction)))))

--- a/scheme/oll-core/internal/music-tools.scm
+++ b/scheme/oll-core/internal/music-tools.scm
@@ -1,0 +1,44 @@
+;%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+;%                                                                             %
+;% This file is part of openLilyLib,                                           %
+;%                      ===========                                            %
+;% the community library project for GNU LilyPond                              %
+;% (https://github.com/openlilylib/openlilylib                                 %
+;%              -----------                                                    %
+;%                                                                             %
+;% openLilyLib is free software: you can redistribute it and/or modify         %
+;% it under the terms of the GNU General Public License as published by        %
+;% the Free Software Foundation, either version 3 of the License, or           %
+;% (at your option) any later version.                                         %
+;%                                                                             %
+;% openLilyLib is distributed in the hope that it will be useful,              %
+;% but WITHOUT ANY WARRANTY; without even the implied warranty of              %
+;% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               %
+;% GNU General Public License for more details.                                %
+;%                                                                             %
+;% You should have received a copy of the GNU General Public License           %
+;% along with openLilyLib. If not, see <http://www.gnu.org/licenses/>.         %
+;%                                                                             %
+;% openLilyLib is maintained by Urs Liska, ul@openlilylib.org                  %
+;% and others.                                                                 %
+;%       Copyright Urs Liska, 2015                                             %
+;%                                                                             %
+;%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+;; This files contains general-purpose tools to work with music expressions
+
+(define-module (oll-core internal music-tools))
+
+(use-modules (lily))
+
+(define-public (music-name music)
+  "Return the name/type of the music expression
+   or #f if not ly:music?"
+  (and (ly:music? music)
+       (ly:music-property music 'name)))
+
+(define-public (music-is? music name)
+  "Return #t if the given music has the given name/type,
+   #f otherwise."
+  (and (ly:music? music)
+       (eq? name (music-name music))))


### PR DESCRIPTION
This is intended to become a larger collection of tools to (simplify the) work with grobs, in engravers and callbacks.

* `grob-name` is just a convenience function for a regularly used pattern
* `filter-grobs-by-name` can for example be used to find elements in a current grob's parent NoteColumn (I used it to find a TextScript attached to a Slur's beginning)
* `stem-direction` can be used to to determine the actual direction of a note, to force a grob to the stem or the notehead side.