### PR TITLE
Revert "Remove definition of alist? predicate"

### DIFF
--- a/internal/predicates.scm
+++ b/internal/predicates.scm
@@ -16,6 +16,13 @@
   (or (symbol? obj)
       (ly:context-mod? obj)))
 
+
+; temporary predicate, as this seems just too general ...
+(define (alist? obj)
+  (if (and (list? obj)
+           (every pair? obj))
+      #t #f))
+
 ; Predicate for a mandatory option:
 ; a three-element list consisting of
 ; - name (symbol?)
@@ -98,6 +105,7 @@
 
 
 (export al-or-props?)
+(export alist?)
 (export oll-mand-prop?)
 (export oll-mand-props?)
 (export oll-accepted-prop?)


### PR DESCRIPTION
This reverts commit 0d9d0bd4429a71609ab08d4d02f1453a336ed39c.

alist? was only introduced in LilyPond 2.23.10, we want to support
earlier versions too, like the current stable version 2.22.

@markk